### PR TITLE
write empty tseries with a single NA value

### DIFF
--- a/src/Bridge.jl
+++ b/src/Bridge.jl
@@ -264,7 +264,7 @@ unfame(fo::FameObject{:series,:numeric,FR}) where {FR} =
 unfame(fo::FameObject{:series,:string,FR}) where {FR} =
     copy(fo.data) # error("Can't handle string series")
 function unfame(fo::FameObject{:series,TY,FR}) where {TY,FR}
-    if length(fo.data) == 1 && _ismissing(fo.data[1], Val(:FR))
+    if length(fo.data) == 1 && _ismissing(fo.data[1], Val(TY))
         TSeries(MIT{_freq_from_fame(TY)}, _date_to_mit(FR, fo.first_index[]))
     else
         return TSeries(_date_to_mit(FR, fo.first_index[]), [_date_to_mit(TY, d) for d in fo.data])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,8 @@ end
     pr[2020Q4] = NaN
     nu = TSeries(2020Q1, randn(Float32, 8))
     nu[2020Q4] = NaN
-    writefame(workdb(), Workspace(; pr, nu))
+    test_db = workdb()
+    writefame(test_db, Workspace(; pr, nu))
     for n in ("pr", "nu")
         let b = IOBuffer()
             fame(b, "disp $n")
@@ -72,26 +73,37 @@ end
 @testset "empty tseries" begin
     w = Workspace(; 
         t1 = TSeries(1995Q1),
-        t2 = TSeries(1993Q3, Vector{Float32}()),
-        t3 = TSeries(1996Q2, Vector{Bool}()),
-        t4 = TSeries(1996Q2, Vector{Bool}([true, false, true]))
+        t2 = TSeries(Float32, 1993Q3),
+        t3 = TSeries(Bool, 1996Q2),
+        t4 = TSeries(1996Q2, Vector{Bool}([true, false, true])),
+        t5 = TSeries(MIT{Yearly}, 1998Q3),
+        t6 = TSeries(1997Q1, Vector{MIT{Yearly}}([2022Y, 2023Y]))
     )
-    writefame("data.db", w)
-    @test length(listdb("data.db")) == 4
+    writefame("empty_series_test.db", w)
+    @test length(listdb("empty_series_test.db")) == 6
 
-    wr = readfame("data.db")
-
+    wr = readfame("empty_series_test.db")
+   
     @test typeof(wr.t1) == TSeries{Quarterly, Float64, Vector{Float64}}
     @test typeof(wr.t2) == TSeries{Quarterly, Float32, Vector{Float32}}
     @test typeof(wr.t3) == TSeries{Quarterly, Bool, Vector{Bool}}
     @test typeof(wr.t4) == TSeries{Quarterly, Bool, Vector{Bool}}
+    @test typeof(wr.t5) == TSeries{Quarterly, MIT{Yearly}, Vector{MIT{Yearly}}}
+    @test typeof(wr.t6) == TSeries{Quarterly, MIT{Yearly}, Vector{MIT{Yearly}}}
     @test wr.t1.firstdate == 1995Q1
     @test wr.t2.firstdate == 1993Q3
     @test wr.t3.firstdate == 1996Q2
     @test wr.t4.firstdate == 1996Q2
+    @test wr.t5.firstdate == 1998Q3
+    @test wr.t6.firstdate == 1997Q1
     @test length(wr.t1) == 0
     @test length(wr.t2) == 0
     @test length(wr.t3) == 0
     @test length(wr.t4) == 3
+    @test length(wr.t5) == 0
+    @test length(wr.t6) == 2
     @test wr.t4.values == [true, false, true]
+    @test wr.t6.values == [2022Y, 2023Y]
+
+    rm("empty_series_test.db")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,3 +68,25 @@ end
         end
     end
 end
+
+@testset "empty tseries" begin
+    w = Workspace(; 
+        t1 = TSeries(1995Q1),
+        t2 = TSeries(1993Q3, Vector{Float32}()),
+        t3 = TSeries(1996Q2, Vector{Bool}())
+    )
+    writefame("data.db", w)
+    @test length(listdb("data.db")) == 3
+
+    wr = readfame("data.db")
+
+    @test typeof(wr.t1) == TSeries{Quarterly, Float64, Vector{Float64}}
+    @test typeof(wr.t2) == TSeries{Quarterly, Float32, Vector{Float32}}
+    @test typeof(wr.t3) == TSeries{Quarterly, Bool, Vector{Bool}}
+    @test wr.t1.firstdate == 1995Q1
+    @test wr.t2.firstdate == 1993Q3
+    @test wr.t3.firstdate == 1996Q2
+    @test length(wr.t1) == 0
+    @test length(wr.t2) == 0
+    @test length(wr.t3) == 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,9 @@ end
 end
 
 @testset "empty tseries" begin
+    FAME.init_chli()
+    test_db = workdb()
+
     w = Workspace(; 
         t1 = TSeries(1995Q1),
         t2 = TSeries(Float32, 1993Q3),
@@ -79,10 +82,10 @@ end
         t5 = TSeries(MIT{Yearly}, 1998Q3),
         t6 = TSeries(1997Q1, Vector{MIT{Yearly}}([2022Y, 2023Y]))
     )
-    writefame("empty_series_test.db", w)
-    @test length(listdb("empty_series_test.db")) == 6
+    writefame(test_db, w)
+    @test length(listdb(test_db)) == 6
 
-    wr = readfame("empty_series_test.db")
+    wr = readfame(test_db)
    
     @test typeof(wr.t1) == TSeries{Quarterly, Float64, Vector{Float64}}
     @test typeof(wr.t2) == TSeries{Quarterly, Float32, Vector{Float32}}
@@ -105,5 +108,4 @@ end
     @test wr.t4.values == [true, false, true]
     @test wr.t6.values == [2022Y, 2023Y]
 
-    rm("empty_series_test.db")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,20 +73,25 @@ end
     w = Workspace(; 
         t1 = TSeries(1995Q1),
         t2 = TSeries(1993Q3, Vector{Float32}()),
-        t3 = TSeries(1996Q2, Vector{Bool}())
+        t3 = TSeries(1996Q2, Vector{Bool}()),
+        t4 = TSeries(1996Q2, Vector{Bool}([true, false, true]))
     )
     writefame("data.db", w)
-    @test length(listdb("data.db")) == 3
+    @test length(listdb("data.db")) == 4
 
     wr = readfame("data.db")
 
     @test typeof(wr.t1) == TSeries{Quarterly, Float64, Vector{Float64}}
     @test typeof(wr.t2) == TSeries{Quarterly, Float32, Vector{Float32}}
     @test typeof(wr.t3) == TSeries{Quarterly, Bool, Vector{Bool}}
+    @test typeof(wr.t4) == TSeries{Quarterly, Bool, Vector{Bool}}
     @test wr.t1.firstdate == 1995Q1
     @test wr.t2.firstdate == 1993Q3
     @test wr.t3.firstdate == 1996Q2
+    @test wr.t4.firstdate == 1996Q2
     @test length(wr.t1) == 0
     @test length(wr.t2) == 0
     @test length(wr.t3) == 0
+    @test length(wr.t4) == 3
+    @test wr.t4.values == [true, false, true]
 end


### PR DESCRIPTION
This is a proposed fix for Issue https://github.com/bankofcanada/FAME.jl/issues/8

Empty TSeries are written with a single NA value in the first period of their range. Series with a single NA value are in turn interpreted as an empty TSeries when being written.

There are also some tests added.

